### PR TITLE
Compatibilidade para números com DDD

### DIFF
--- a/maskbrphone.js
+++ b/maskbrphone.js
@@ -23,21 +23,21 @@
         };
 
         var applyMask = function(input) {
-
+        	
             var fone = input
                     .replace(/\D/g, '') // Remove tudo o que não for dígito
-                    .substring(0, 9); // Limita em 9 caracteres;
-
+                    .substring(0, 11); // Limita em 11 caracteres;
+            
             var maskedPhone;
-
-            if (fone.length <= 8) {
-                // Coloca hífen entre o quarto e o quinto dígito
-                maskedPhone = fone.replace(/(\d{4})(\d{1,4})/, '$1-$2');
-            } else {
-                // Coloca hífen entre o quinto e o sexto dígito
-                maskedPhone = fone.replace(/(\d{5})(\d{1,4})/, '$1-$2');
+            
+            if (fone.length <= 9) {
+                // Coloca hífen quando o número NÃO possui DDD
+                maskedPhone = fone.replace(/(\d{4}|\d{5})(\d{1,4})$/g, '$1-$2');
+        	} else {
+            	// Coloca hífen e parênteses quando o número possui DDD
+            	maskedPhone = fone.replace(/(\d{2})?(\d{4}|\d{5})(\d{4})$/g, '($1)$2-$3')
             }
-
+            
             return maskedPhone;
         };
 

--- a/maskbrphone.js
+++ b/maskbrphone.js
@@ -7,8 +7,16 @@
 */
 (function($) {
 
-    $.fn.maskbrphone = function() {
+    $.fn.maskbrphone = function(options) {
 
+    	var defaults = {
+    		dddParenthesis : true,
+            dddSeparator : '',
+            numberSeparator : '-'
+        };
+
+        var settings = $.extend( {}, defaults, options );
+    	
         var plugin = this;
 
         var init = function() {
@@ -32,10 +40,21 @@
             
             if (fone.length <= 9) {
                 // Coloca hífen quando o número NÃO possui DDD
-                maskedPhone = fone.replace(/(\d{4}|\d{5})(\d{1,4})$/g, '$1-$2');
+                maskedPhone = fone.replace(/(\d{4}|\d{5})(\d{1,4})$/g, '$1' + settings.numberSeparator + '$2');
         	} else {
+        		var replacement = '';
+        		if (settings.dddParenthesis) {
+        			replacement += '($1)'
+        		} else {
+        			replacement += '$1'
+        		}
+        		replacement += settings.dddSeparator;
+        		replacement += '$2';
+        		replacement += settings.numberSeparator;
+        		replacement += '$3';
+        		
             	// Coloca hífen e parênteses quando o número possui DDD
-            	maskedPhone = fone.replace(/(\d{2})?(\d{4}|\d{5})(\d{4})$/g, '($1)$2-$3')
+            	maskedPhone = fone.replace(/(\d{2})?(\d{4}|\d{5})(\d{4})$/g, replacement);
             }
             
             return maskedPhone;


### PR DESCRIPTION
Segue uma implementação para número com DDD e outra para permitir a configuração de separadores e colocação de paranteses.
Segue um exemplo de utilização dos parametros.
            $('.celular').maskbrphone({
            	dddParenthesis: false,
            	dddSeparator: '_',
            	numberSeparator: '_'
            });